### PR TITLE
Fix undefined method before_filter

### DIFF
--- a/app/controllers/impersonate_controller.rb
+++ b/app/controllers/impersonate_controller.rb
@@ -1,6 +1,6 @@
 class ImpersonateController < ApplicationController
   unloadable
-  before_filter :project, :permission!
+  before_action :project, :permission!
   
   def permission!
     User.current.allowed_to?(:impersonate_project_user,project) || 

--- a/init.rb
+++ b/init.rb
@@ -27,7 +27,7 @@ end
 require_dependency 'application_controller'
 class ApplicationController < ActionController::Base
   unloadable
-  before_filter :impersonate_if_needed
+  before_action :impersonate_if_needed
   def impersonate_if_needed
     if session[:impersonated_user_id]
       User.impersonated_user=User.find(session[:impersonated_user_id])


### PR DESCRIPTION
Fix compatibility on Redmine 4.0.
`before_filter` has been deprecated in Rails 5.0, removed in 5.1 and replaced by `before_action` method.

Signed-off-by: Antoine Chabert <antoine.chabert@tohero.fr>